### PR TITLE
Update CI workflows to remove 'main' branch references and adjust bac…

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3,7 +3,6 @@ name: Backend CI
 on:
   push:
     branches:
-      - main
       - development
     paths:
       - 'backend/**'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -3,7 +3,6 @@ name: Frontend CI
 on:
   push:
     branches:
-      - main
       - development
     paths:
       - 'frontend/**'

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,4 +1,4 @@
-name: Deploy FastAPI to Google Cloud Run
+name: Deploy FastAPI to Google VM
 
 on:
   push:
@@ -10,45 +10,32 @@ on:
 
 jobs:
   deploy:
-    name: Build & Deploy to Cloud Run
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v3
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          fetch-depth: 1
 
-      - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          install_components: 'beta'
-
-      - name: Configure Docker for Google Cloud
+      - name: Set up SSH Access
         run: |
-          gcloud auth configure-docker --quiet
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GCP_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.GCP_VM_IP }} >> ~/.ssh/known_hosts
 
-      - name: Build Docker image
+      - name: Inject .env and Deploy to VM
         run: |
-          IMAGE="gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CLOUD_RUN_SERVICE }}"
-          docker build -t $IMAGE ./backend
-          echo "Built image: $IMAGE"
+          # Create .env file locally with your secret
+          echo "GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}" > backend/.env
 
-      - name: Push Docker image to Google Container Registry
-        run: |
-          IMAGE="gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CLOUD_RUN_SERVICE }}"
-          docker push $IMAGE
+          # Copy backend directory to the VM
+          scp -r ./backend ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_IP }}:/home/${{ secrets.GCP_VM_USER }}/fastapi_app
 
-      - name: Deploy to Cloud Run
-        run: |
-          IMAGE="gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CLOUD_RUN_SERVICE }}"
-          gcloud run deploy ${{ secrets.CLOUD_RUN_SERVICE }} \
-            --image $IMAGE \
-            --region ${{ secrets.REGION }} \
-            --platform managed \
-            --allow-unauthenticated \
-            --quiet
+          # SSH into VM and run the start.sh script
+          ssh ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_IP }} << 'EOF'
+            cd ~/fastapi_app/backend
+            chmod +x start.sh
+            ./start.sh
+          EOF

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ collect_files.py
 .env.development.local
 .env.test.local
 .env.production.local
+
+# SSH
+.ssh/

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+# Create and activate virtual environment
+if [ ! -d "venv" ]; then
+  python3 -m venv venv
+fi
+
+source venv/bin/activate
+
+# Upgrade pip and install dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Load environment variables from .env if exists
+if [ -f ".env" ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+# Kill any existing uvicorn process
+pkill -f "uvicorn" || true
+
+# Start FastAPI app from app.py
+nohup venv/bin/uvicorn app:app --host 0.0.0.0 --port 8080 > log.txt 2>&1 &


### PR DESCRIPTION
This pull request introduces several significant changes to the CI/CD workflows and deployment process for the backend and frontend applications. The most notable updates include modifying the branches monitored by CI workflows, transitioning the backend deployment from Google Cloud Run to a Google VM, and adding a new `start.sh` script for managing the FastAPI application on the VM.

### CI Workflow Updates:

* [`.github/workflows/ci-backend.yml`](diffhunk://#diff-d534d457d2f453ff292b326309bebf3d6b2f7e067ca4247038b61df22d09c728L6): Removed the `main` branch from the list of branches triggering the backend CI workflow, leaving only the `development` branch.
* [`.github/workflows/ci-frontend.yml`](diffhunk://#diff-eb2db7207db87402040437448325e7fc06061106100926394b2d495548d35c6aL6): Similarly, removed the `main` branch from the list of branches triggering the frontend CI workflow, leaving only the `development` branch.

### Backend Deployment Changes:

* [`.github/workflows/deploy-backend.yml`](diffhunk://#diff-2418b8c74e15fc5d4f708e1f98749f0d592abf1991ce915d251f77ed076e5f7dL1-R1): Transitioned the backend deployment process from Google Cloud Run to a Google VM. This involved removing Docker image builds and Cloud Run-specific steps, and replacing them with SSH-based deployment steps, including copying the backend directory to the VM and executing a `start.sh` script. [[1]](diffhunk://#diff-2418b8c74e15fc5d4f708e1f98749f0d592abf1991ce915d251f77ed076e5f7dL1-R1) [[2]](diffhunk://#diff-2418b8c74e15fc5d4f708e1f98749f0d592abf1991ce915d251f77ed076e5f7dL13-R41)

### New Deployment Script:

* [`backend/start.sh`](diffhunk://#diff-228f802dcd9c4563c1f284ed6aff68464a033a66e606cd5870899da2675edd33R1-R25): Added a new script to manage the FastAPI application on the VM. This script sets up a Python virtual environment, installs dependencies, loads environment variables, and starts the FastAPI application using `uvicorn`. It also ensures any existing `uvicorn` processes are terminated before starting a new one

