### PR TITLE
Add arrival time to EnhancedAppointment

### DIFF
--- a/backend/solver/models.py
+++ b/backend/solver/models.py
@@ -44,6 +44,7 @@ class EnhancedAppointment(BaseModel):
     appointment_type: AppointmentType = Field(default_factory=AppointmentType)
     travel_time_to_next_min: Optional[int] = None
     travel_distance_to_next_km: Optional[float] = None
+    arrival_time: Optional[int] = None
 
 class VehicleBreak(BaseModel):
     duration: int  # in minutes

--- a/backend/solver/solver.py
+++ b/backend/solver/solver.py
@@ -227,10 +227,14 @@ def solve_appointment_routing(
         while not routing.IsEnd(index):
             node_index = manager.IndexToNode(index)
 
+            # Arrival time at current node
+            arrival_time = solution.Value(time_dimension.CumulVar(index))
+
             # Add appointment if it's not the depot
             try:
                 if 0 < node_index <= len(optimization_request.appointments):
-                    vehicle_route.append(optimization_request.appointments[node_index - 1])
+                    appointment_with_arrival_time = optimization_request.appointments[node_index - 1].copy(update = {"arrival_time": arrival_time})
+                    vehicle_route.append(appointment_with_arrival_time)
             except IndexError:
                 print(f"Invalid node_index={node_index} for appointments (len={len(optimization_request.appointments)})")
 
@@ -241,9 +245,6 @@ def solve_appointment_routing(
             # Travel time and distance
             travel_time = optimization_request.time_matrix[from_node][to_node]
             travel_distance = optimization_request.distance_matrix[from_node][to_node]
-
-            # Arrival time at current node
-            arrival_time = solution.Value(time_dimension.CumulVar(index))
 
             # Service time and waiting time
             waiting_time = 0


### PR DESCRIPTION
Add arrival time to EnhancedAppointment. It´s provided by OR-tools and now it´s added to the  EnhancedAppointment before adding the EnhancedAppointment  to the route.

Departure time is not provided, since there is not necessarily one departure time.
It can be easily calculated via arrival_time + service_time as the earliest possible departure time.

![grafik](https://github.com/user-attachments/assets/25f72fa4-a4e4-4aa7-b513-8153e9338b6c)
